### PR TITLE
Fix 404 links and homogenize URIs

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -64,7 +64,7 @@
             </button>
             <ul class="mdl-menu mdl-js-menu mdl-menu--bottom-right mdl-js-ripple-effect" for="more-button">
                 <li class="mdl-menu__item"><a class="mdl-color-text--black"
-                                              href="https://github.com/MikeMitterer/dart-material-design-lite "
+                                              href="https://github.com/MikeMitterer/dart-material-design-lite"
                                               target="_blank">GitHub</a></li>
                 <li class="mdl-menu__item"><a class="mdl-color-text--black"
                                               href="http://styleguide.material-design-lite.pub/" target="_blank">Styleguide</a>
@@ -210,7 +210,7 @@ main() &#123;
                                           <span>
                                               MDL/Dart-Code is easy to read.<br>
                                               The component-registration has about 55 lines of code.<br>
-                                              More on <a href="https://goo.gl/eIujlK" target="_blank">GitHub</a>
+                                              More on <a href="https://github.com/MikeMitterer/dart-material-design-lite/blob/master/lib/src/core/MdlComponentHandler.dart#l409-l464" target="_blank">GitHub</a>
                                           </span>
                                     </li>
 
@@ -234,18 +234,18 @@ main() &#123;
                                             You can use classes, attributes or tags as your component<br>
                                             (Not supported in MDL/JS)<br>
                                             E.g. MaterialCheckbox uses mdl-js-checkbox for the <a
-                                                  href="https://goo.gl/ZcXdsM"
+                                                  href="https://github.com/MikeMitterer/dart-material-design-lite-site/blob/samples2site/samples/mdl_checkbox/web/index.html#l53-l56"
                                                   target="_blank">Component-Registration</a><br>
                                             The D&D sample uses the mdl-draggable tag<br>
-                                            as basis for the <a href="https://goo.gl/szzVrH"
+                                            as basis for the <a href="https://github.com/MikeMitterer/dart-material-design-lite-site/blob/samples2site/samples/mdlx_dnd/web/index.html#l59-l61"
                                                                 target="_blank">Component: </a> - it's up to you!<br>
-                                            MaterialObserver uses an attribute as <a href="https://goo.gl/7JzQzq"
+                                            MaterialObserver uses an attribute as <a href="https://github.com/MikeMitterer/dart-material-design-lite/blob/master/lib/src/directive/components/MaterialObserve.dart#l126"
                                                                                      target="_blank">basis</a><br>
                                           </span>
                                     </li>
 
                                     <li><i class="material-icons mdl-color-text--green">check</i>
-                                        <a href="https://goo.gl/2a5K1O" target="_blank">Easy to use public component
+                                        <a href="https://github.com/MikeMitterer/dart-material-design-lite-site/blob/samples2site/samples/mdl_spinner/web/main.dart#l14-l20" target="_blank">Easy to use public component
                                             functions</a><br>
                                     </li>
 
@@ -263,7 +263,7 @@ main() &#123;
                                           Theming<br>
                                           Sure Polymer has theming but with it's encapsulation approach<br>
                                           it's more a pain then it helps.<br>
-                                          Here are the SCSS-Themes: <a href="https://goo.gl/iBc6kE" target="_blank">GitHub</a>
+                                          Here are the SCSS-Themes: <a href="https://github.com/MikeMitterer/dart-material-design-lite/tree/master/lib/assets/themes" target="_blank">GitHub</a>
                                           </span>
                                     </li>
 
@@ -356,11 +356,11 @@ main() &#123;
                                     </li>
                                     <li>Routing (<a href="http://styleguide.material-design-lite.pub/" target="_blank">Styleguide</a>)
                                     </li>
-                                    <li>Write your own components (<a href="https://goo.gl/3dMnfP" target="_blank">GitHub</a>)
+                                    <li>Write your own components (<a href="https://github.com/MikeMitterer/dart-material-design-lite-site/tree/samples2site/samples/spa_todo" target="_blank">GitHub</a>)
                                     </li>
-                                    <li>Easy to use SCSS-Components (<a href="https://goo.gl/dlm27Q" target="_blank">GitHub</a>)
+                                    <li>Easy to use SCSS-Components (<a href="https://github.com/MikeMitterer/dart-material-design-lite/tree/master/lib/assets/styles" target="_blank">GitHub</a>)
                                     </li>
-                                    <li>Dependency injection (<a href="https://goo.gl/GjFflr" target="_blank">GitHub</a>)
+                                    <li>Dependency injection (<a href="https://github.com/MikeMitterer/dart-material-design-lite-site/blob/samples2site/samples/styleguide/web/main.dart#l195-l202" target="_blank">GitHub</a>)
                                     </li>
                                     <li>Samples, samples, samples (<a
                                             href="http://styleguide.material-design-lite.pub/#/samples" target="_blank">Styleguide</a>)
@@ -406,7 +406,7 @@ main() &#123;
                                         your HTML
                                     </li>
                                     <li><span>
-                                        <a href="https://goo.gl/OzCyoK"
+                                        <a href="https://github.com/MikeMitterer/dart-material-design-lite-site/blob/samples2site/samples/spa_todo/lib/src/ToDoItem.dart#l138-l160"
                                            target="_blank">Mustache-Based-Components (Template-Based)</a><br>
                                         E.g. define your event-handler in HTML:<br>
                                         <pre class="prettyprint html" style="max-width: 300px;">&lt;button class=&quot;mdl-button mdl-js-button mdl-button--colored mdl-js-ripple-effect&quot;
@@ -416,7 +416,7 @@ main() &#123;
                                     <li>You are not tied to css-class-based components. Choose weither your own
                                         componentd
                                         should be
-                                        class-bases, attribute-based or tag-based! (<a href="https://goo.gl/rB7goh"
+                                        class-bases, attribute-based or tag-based! (<a href="https://github.com/MikeMitterer/dart-material-design-lite-site/blob/samples2site/samples/spa_todo/lib/src/ToDoItem.dart#l169"
                                                                                        target="_blank">GitHub</a>)
                                     </li>
                                 </ul>
@@ -597,7 +597,7 @@ localhost:8000</pre>
                                     simple.zip</label>
                                 <div class="mdl-accordion--content">
                                     <p class="mdl-accordion--body">Download
-                                        <a href="https://cdn.rawgit.com/MikeMitterer/dart-material-design-lite/master/site/downloads/simple.zip"
+                                        <a href="https://raw.githubusercontent.com/MikeMitterer/dart-material-design-lite-site/samples2site/web/downloads/simple.zip"
                                            class="mdl-color-text--grey">simple.zip</a><br>
                                         Unzip the downloaded file<br>
                                         cd simple<br>


### PR DESCRIPTION
- Fix multiple broken links to GitHub.
- Homogenize all GitHub links to use full URIS instead of shorteners, for better maintainability and accurate representation of target.
